### PR TITLE
Enable Failed Login Message

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -35,6 +35,11 @@ module.exports = {
                     authenticated: true,
                     token: res.token
                 })
+            },
+            error: (xhr, status, err) => {
+                cb({
+                    authenticated: false
+                })
             }
         })
     }, 


### PR DESCRIPTION
Added the AJAX error response in case If the username or password is incorrect, sets authenticated to false.